### PR TITLE
Add multi-provider chat and Apps Script endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Codex Guidelines
+
+This project uses Vite with a Cloudflare Worker backend. After modifying code, run `npm run lint` to ensure consistency.
+
+## Suggested Improvements
+- Cache model lists server-side to reduce network requests.
+- Consider using the official Apps Script API instead of the `clasp` CLI for better portability.
+- Add unit tests with Vitest for API endpoints and worker logic.
+- Provide error handling for missing environment variables.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Workers Vercel AI Starter
 
-A chat application powered by Google Gemini AI, the Vercel AI SDK, and Cloudflare Workers. It provides a simple interface for interacting with an AI model, rendered with Shadcn UI components and Tailwind CSS.
+A chat application powered by Google Gemini AI, OpenAI, and Cloudflare Workers AI. It provides a simple interface for interacting with different AI providers, rendered with Shadcn UI components and Tailwind CSS.
 
 ## Deploy
 
@@ -8,4 +8,11 @@ First, use the button below to deploy this project to Cloudflare Workers.
 
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/kristianfreeman/workers-vercel-ai-starter)
 
-**IMPORTANT:** Once deployed, access the newly deployed application in your dashboard and set the `GOOGLE_GENERATIVE_AI_API_KEY` environment variable to your Gemini API key ([instructions](https://ai.google.dev/gemini-api/docs/api-key)). After redeploying the application, the API endpoint will automatically use this key and interact with the Gemini API.
+**IMPORTANT:** Once deployed, access the newly deployed application in your dashboard and set the following environment variables:
+
+- `GOOGLE_GENERATIVE_AI_API_KEY` – Gemini API key ([instructions](https://ai.google.dev/gemini-api/docs/api-key))
+- `OPENAI_API_KEY` – OpenAI API key
+- `CLOUDFLARE_AI_TOKEN` – API token for Workers AI
+- `CLOUDFLARE_ACCOUNT_ID` – your Cloudflare account id
+
+After redeploying the application, the API endpoint will automatically use these keys to interact with the selected provider.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ First, use the button below to deploy this project to Cloudflare Workers.
 **IMPORTANT:** Once deployed, access the newly deployed application in your dashboard and set the following environment variables:
 
 - `GOOGLE_GENERATIVE_AI_API_KEY` – Gemini API key ([instructions](https://ai.google.dev/gemini-api/docs/api-key))
+- `GOOGLE_APPS_SCRIPT_API_KEY` – Google Apps Script API key for project management
 - `OPENAI_API_KEY` – OpenAI API key
 - `CLOUDFLARE_AI_TOKEN` – API token for Workers AI
 - `CLOUDFLARE_ACCOUNT_ID` – your Cloudflare account id

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
 		"cf-typegen": "wrangler types"
 	},
 	"dependencies": {
-		"@ai-sdk/google": "^1.2.14",
-		"@ai-sdk/react": "^1.2.9",
+                "@ai-sdk/google": "^1.2.14",
+                "@ai-sdk/openai": "^1.2.14",
+                "@ai-sdk/cloudflare": "^1.2.14",
+                "@ai-sdk/react": "^1.2.9",
 		"@radix-ui/react-avatar": "^1.1.7",
 		"@radix-ui/react-scroll-area": "^1.2.6",
 		"@radix-ui/react-slot": "^1.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import Chat from "@/components/chat";
-import { Card, CardHeader, CardTitle, } from "@/components/ui/card";
+import Projects from "@/components/projects";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 export default function App() {
   return (
@@ -11,6 +12,9 @@ export default function App() {
           </CardTitle>
           <p className="text-sm text-muted-foreground">Powered by Vercel AI SDK, Cloudflare Workers, and Google Gemini AI</p>
         </CardHeader>
+        <CardContent>
+          <Projects />
+        </CardContent>
         <Chat />
       </Card>
     </div>

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -49,13 +49,19 @@ export default function Chat() {
     fetch(`/api/models?provider=${provider}`)
       .then((r) => r.json())
       .then((data) => {
-        const items = (data.models || data.data || []).map((m: any) => m.id || m.name || m);
-        setModels(items);
-        if (items.length > 0) {
-          setModel(items[0]);
+        const models = data.models || [];
+        setModels(models);
+        if (models.length > 0) {
+          setModel(models[0]);
+        } else {
+          setModel('');
         }
       })
-      .catch(() => setModels([]));
+      .catch((error) => {
+        console.error(`Failed to fetch models for ${provider}:`, error);
+        setModels([]);
+        setModel('');
+      });
   }, [provider]);
 
   return (

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -12,7 +12,7 @@ import { useChat, type Message } from "@ai-sdk/react";
 import { useEffect, useState } from "react";
 
 const EMPTY_STATE_MESSAGE = `
-# Welcome, slut!
+# Welcome!
 
 This is a chat application powered by:
 

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -13,7 +13,13 @@ export default function Projects() {
   useEffect(() => {
     fetch("/api/projects")
       .then((r) => r.json())
-      .then((data) => setProjects(data as Project[]))
+      .then((data) => {
+        if (data.error) {
+          setProjects([]);
+        } else {
+          setProjects(data);
+        }
+      })
       .catch(() => setProjects([]));
   }, []);
 
@@ -28,8 +34,12 @@ export default function Projects() {
   return (
     <div className="space-y-2">
       <h2 className="font-bold">Apps Script Projects</h2>
+      <div className="text-sm text-gray-600 bg-yellow-50 p-3 rounded border">
+        <strong>Note:</strong> Apps Script integration is temporarily disabled due to security and compatibility issues. 
+        This feature requires a complete rewrite to use the Google Apps Script API instead of the clasp CLI.
+      </div>
       <ul className="space-y-1">
-        {projects.map((p: Project) => (
+        {projects.map((p) => (
           <li key={p.id}>
             <button
               className="underline"

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -1,14 +1,19 @@
 import { useEffect, useState } from "react";
 
+interface Project {
+  id: string;
+  title?: string;
+}
+
 export default function Projects() {
-  const [projects, setProjects] = useState<any[]>([]);
+  const [projects, setProjects] = useState<Project[]>([]);
   const [files, setFiles] = useState<string[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
 
   useEffect(() => {
     fetch("/api/projects")
       .then((r) => r.json())
-      .then((data) => setProjects(data))
+      .then((data) => setProjects(data as Project[]))
       .catch(() => setProjects([]));
   }, []);
 
@@ -24,7 +29,7 @@ export default function Projects() {
     <div className="space-y-2">
       <h2 className="font-bold">Apps Script Projects</h2>
       <ul className="space-y-1">
-        {projects.map((p) => (
+        {projects.map((p: Project) => (
           <li key={p.id}>
             <button
               className="underline"

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+
+export default function Projects() {
+  const [projects, setProjects] = useState<any[]>([]);
+  const [files, setFiles] = useState<string[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/projects")
+      .then((r) => r.json())
+      .then((data) => setProjects(data))
+      .catch(() => setProjects([]));
+  }, []);
+
+  const openProject = (id: string) => {
+    setSelected(id);
+    fetch(`/api/project/files?id=${id}`)
+      .then((r) => r.json())
+      .then((d) => setFiles(d.files || []))
+      .catch(() => setFiles([]));
+  };
+
+  return (
+    <div className="space-y-2">
+      <h2 className="font-bold">Apps Script Projects</h2>
+      <ul className="space-y-1">
+        {projects.map((p) => (
+          <li key={p.id}>
+            <button
+              className="underline"
+              onClick={() => openProject(p.id)}
+            >
+              {p.title || p.id}
+            </button>
+          </li>
+        ))}
+      </ul>
+      {selected && (
+        <div className="mt-4">
+          <h3 className="font-semibold">Files</h3>
+          <ul className="space-y-1">
+            {files.map((f) => (
+              <li key={f}>{f}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -13,13 +13,7 @@ export default function Projects() {
   useEffect(() => {
     fetch("/api/projects")
       .then((r) => r.json())
-      .then((data) => {
-        if (data.error) {
-          setProjects([]);
-        } else {
-          setProjects(data);
-        }
-      })
+      .then((data) => setProjects(data))
       .catch(() => setProjects([]));
   }, []);
 
@@ -34,10 +28,6 @@ export default function Projects() {
   return (
     <div className="space-y-2">
       <h2 className="font-bold">Apps Script Projects</h2>
-      <div className="text-sm text-gray-600 bg-yellow-50 p-3 rounded border">
-        <strong>Note:</strong> Apps Script integration is temporarily disabled due to security and compatibility issues. 
-        This feature requires a complete rewrite to use the Google Apps Script API instead of the clasp CLI.
-      </div>
       <ul className="space-y-1">
         {projects.map((p) => (
           <li key={p.id}>

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -107,16 +107,16 @@ export default {
       }
       case "/api/project/files": {
         const id = url.searchParams.get("id");
-        if (!id) {
-          return new Response("Missing id", { status: 400 });
+        if (!id || !/^[a-zA-Z0-9_-]+$/.test(id)) {
+          return new Response("Invalid or missing id", { status: 400 });
         }
         return new Promise((resolve) => {
-          exec(`clasp pull --scriptId ${id} --rootDir /tmp/${id}`, (err) => {
+          execFile("clasp", ["pull", "--scriptId", id, "--rootDir", `/tmp/${id}`], (err) => {
             if (err) {
               resolve(new Response("pull failed", { status: 500 }));
               return;
             }
-            exec(`ls /tmp/${id}`, (err2, out) => {
+            execFile("ls", [`/tmp/${id}`], (err2, out) => {
               if (err2) {
                 resolve(new Response("list failed", { status: 500 }));
               } else {

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -28,18 +28,18 @@ export default {
         switch (provider) {
           case "gemini": {
             if (!env.GOOGLE_GENERATIVE_AI_API_KEY) {
-              return new Response("Gemini API key is not configured.", { status: 500 });
+              return new Response("Gemini API key not configured", { status: 500 });
             }
-            const gemini = google(model || 'gemini-1.5-pro-latest', {
+            const geminiModel = google(model || 'gemini-1.5-pro-latest', {
               apiKey: env.GOOGLE_GENERATIVE_AI_API_KEY,
               useSearchGrounding: true,
             });
-            const result = streamText({ model: gemini, messages });
+            const result = streamText({ model: geminiModel, messages });
             return result.toDataStreamResponse();
           }
           case "openai": {
             if (!env.OPENAI_API_KEY) {
-              return new Response("OpenAI API key is not configured.", { status: 500 });
+              return new Response("OpenAI API key not configured", { status: 500 });
             }
             const openaiModel = openai(model, { apiKey: env.OPENAI_API_KEY });
             const result = streamText({ model: openaiModel, messages });
@@ -47,10 +47,10 @@ export default {
           }
           case "cloudflare": {
             if (!env.CLOUDFLARE_AI_TOKEN || !env.CLOUDFLARE_ACCOUNT_ID) {
-              return new Response("Cloudflare AI credentials are not configured.", { status: 500 });
+              return new Response("Cloudflare AI credentials not configured", { status: 500 });
             }
             const cloudflareModel = cloudflare(model, {
-              apiToken: env.CLOUDFLARE_AI_TOKEN,
+              apiKey: env.CLOUDFLARE_AI_TOKEN,
               accountId: env.CLOUDFLARE_ACCOUNT_ID,
             });
             const result = streamText({ model: cloudflareModel, messages });
@@ -120,19 +120,17 @@ export default {
         }
       }
       case "/api/projects": {
-        // REMOVED: Apps Script integration using exec is a security vulnerability
-        // and incompatible with Cloudflare Workers runtime.
-        // TODO: Implement using Google Apps Script API directly
-        return new Response(JSON.stringify({ error: "Apps Script integration temporarily disabled for security" }), {
+        // Apps Script integration removed due to security and runtime incompatibility issues
+        // This feature would require using the Google Apps Script API instead of clasp CLI
+        return new Response(JSON.stringify({ error: "Apps Script integration temporarily disabled" }), {
           status: 501,
           headers: { "Content-Type": "application/json" }
         });
       }
       case "/api/project/files": {
-        // REMOVED: Apps Script integration using exec is a security vulnerability
-        // and incompatible with Cloudflare Workers runtime. 
-        // TODO: Implement using Google Apps Script API directly
-        return new Response(JSON.stringify({ error: "Apps Script integration temporarily disabled for security" }), {
+        // Apps Script integration removed due to security and runtime incompatibility issues
+        // This feature would require using the Google Apps Script API instead of clasp CLI
+        return new Response(JSON.stringify({ error: "Apps Script integration temporarily disabled" }), {
           status: 501,
           headers: { "Content-Type": "application/json" }
         });

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,24 +1,131 @@
 import type { Message } from 'ai';
 import { google } from '@ai-sdk/google';
 import { streamText } from 'ai';
+import { exec } from 'node:child_process';
+
+interface Env {
+  GOOGLE_GENERATIVE_AI_API_KEY: string;
+  OPENAI_API_KEY: string;
+  CLOUDFLARE_AI_TOKEN: string;
+  CLOUDFLARE_ACCOUNT_ID: string;
+}
 
 type JsonBody = {
-  id: string;
+  id?: string;
+  provider: string;
+  model: string;
   messages: Message[];
 };
 
 export default {
-  async fetch(request) {
+  async fetch(request: Request, env: Env) {
     const url = new URL(request.url);
 
     switch (url.pathname) {
       case "/api/chat": {
-        const { messages } = await request.json<JsonBody>();
-        const model = google('gemini-1.5-pro-latest', {
-          useSearchGrounding: true
+        const { provider, model, messages } = await request.json<JsonBody>();
+        switch (provider) {
+          case "gemini": {
+            const gemini = google(model || 'gemini-1.5-pro-latest', {
+              apiKey: env.GOOGLE_GENERATIVE_AI_API_KEY,
+              useSearchGrounding: true,
+            });
+            const result = streamText({ model: gemini, messages });
+            return result.toDataStreamResponse();
+          }
+          case "openai": {
+            const res = await fetch("https://api.openai.com/v1/chat/completions", {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${env.OPENAI_API_KEY}`,
+              },
+              body: JSON.stringify({
+                model,
+                messages,
+                stream: true,
+              }),
+            });
+            return new Response(res.body, {
+              headers: { "Content-Type": "text/event-stream" },
+            });
+          }
+          case "cloudflare": {
+            const cfUrl = `https://api.cloudflare.com/client/v4/accounts/${env.CLOUDFLARE_ACCOUNT_ID}/ai/run/${model}`;
+            const cfRes = await fetch(cfUrl, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${env.CLOUDFLARE_AI_TOKEN}`,
+              },
+              body: JSON.stringify({ messages }),
+            });
+            return new Response(cfRes.body, {
+              headers: { "Content-Type": "text/event-stream" },
+            });
+          }
+          default:
+            return new Response("Unknown provider", { status: 400 });
+        }
+      }
+      case "/api/models": {
+        const provider = url.searchParams.get("provider");
+        switch (provider) {
+          case "gemini": {
+            const res = await fetch(
+              `https://generativelanguage.googleapis.com/v1/models?key=${env.GOOGLE_GENERATIVE_AI_API_KEY}`
+            );
+            return new Response(await res.text(), { headers: { "Content-Type": "application/json" } });
+          }
+          case "openai": {
+            const res = await fetch("https://api.openai.com/v1/models", {
+              headers: { Authorization: `Bearer ${env.OPENAI_API_KEY}` },
+            });
+            return new Response(await res.text(), { headers: { "Content-Type": "application/json" } });
+          }
+          case "cloudflare": {
+            const cfUrl = `https://api.cloudflare.com/client/v4/accounts/${env.CLOUDFLARE_ACCOUNT_ID}/ai/models`;
+            const res = await fetch(cfUrl, {
+              headers: { Authorization: `Bearer ${env.CLOUDFLARE_AI_TOKEN}` },
+            });
+            return new Response(await res.text(), { headers: { "Content-Type": "application/json" } });
+          }
+          default:
+            return new Response(JSON.stringify({ models: [] }), { headers: { "Content-Type": "application/json" } });
+        }
+      }
+      case "/api/projects": {
+        return new Promise((resolve) => {
+          exec("clasp list --json", (err, stdout, stderr) => {
+            if (err) {
+              resolve(new Response(stderr, { status: 500 }));
+            } else {
+              resolve(new Response(stdout, { headers: { "Content-Type": "application/json" } }));
+            }
+          });
         });
-        const result = streamText({ model, messages });
-        return result.toDataStreamResponse();
+      }
+      case "/api/project/files": {
+        const id = url.searchParams.get("id");
+        if (!id) {
+          return new Response("Missing id", { status: 400 });
+        }
+        return new Promise((resolve) => {
+          exec(`clasp pull --scriptId ${id} --rootDir /tmp/${id}`, (err) => {
+            if (err) {
+              resolve(new Response("pull failed", { status: 500 }));
+              return;
+            }
+            exec(`ls /tmp/${id}`, (err2, out) => {
+              if (err2) {
+                resolve(new Response("list failed", { status: 500 }));
+              } else {
+                const files = out.split("\n").filter(Boolean);
+                resolve(new Response(JSON.stringify({ files }), { headers: { "Content-Type": "application/json" } }));
+              }
+            });
+          });
+        });
       }
       default: {
         return new Response(null, { status: 404 });

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,11 +1,10 @@
 import type { Message } from 'ai';
 import { google } from '@ai-sdk/google';
-import { openai } from '@ai-sdk/openai';
-import { cloudflare } from '@ai-sdk/cloudflare';
 import { streamText } from 'ai';
 
 interface Env {
   GOOGLE_GENERATIVE_AI_API_KEY: string;
+  GOOGLE_APPS_SCRIPT_API_KEY: string;
   OPENAI_API_KEY: string;
   CLOUDFLARE_AI_TOKEN: string;
   CLOUDFLARE_ACCOUNT_ID: string;
@@ -27,34 +26,43 @@ export default {
         const { provider, model, messages } = await request.json<JsonBody>();
         switch (provider) {
           case "gemini": {
-            if (!env.GOOGLE_GENERATIVE_AI_API_KEY) {
-              return new Response("Gemini API key not configured", { status: 500 });
-            }
-            const geminiModel = google(model || 'gemini-1.5-pro-latest', {
+            const gemini = google(model || 'gemini-1.5-pro-latest', {
               apiKey: env.GOOGLE_GENERATIVE_AI_API_KEY,
               useSearchGrounding: true,
             });
-            const result = streamText({ model: geminiModel, messages });
+            const result = streamText({ model: gemini, messages });
             return result.toDataStreamResponse();
           }
           case "openai": {
-            if (!env.OPENAI_API_KEY) {
-              return new Response("OpenAI API key not configured", { status: 500 });
-            }
-            const openaiModel = openai(model, { apiKey: env.OPENAI_API_KEY });
-            const result = streamText({ model: openaiModel, messages });
-            return result.toDataStreamResponse();
+            const res = await fetch("https://api.openai.com/v1/chat/completions", {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${env.OPENAI_API_KEY}`,
+              },
+              body: JSON.stringify({
+                model,
+                messages,
+                stream: true,
+              }),
+            });
+            return new Response(res.body, {
+              headers: { "Content-Type": "text/event-stream" },
+            });
           }
           case "cloudflare": {
-            if (!env.CLOUDFLARE_AI_TOKEN || !env.CLOUDFLARE_ACCOUNT_ID) {
-              return new Response("Cloudflare AI credentials not configured", { status: 500 });
-            }
-            const cloudflareModel = cloudflare(model, {
-              apiKey: env.CLOUDFLARE_AI_TOKEN,
-              accountId: env.CLOUDFLARE_ACCOUNT_ID,
+            const cfUrl = `https://api.cloudflare.com/client/v4/accounts/${env.CLOUDFLARE_ACCOUNT_ID}/ai/run/${model}`;
+            const cfRes = await fetch(cfUrl, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${env.CLOUDFLARE_AI_TOKEN}`,
+              },
+              body: JSON.stringify({ messages }),
             });
-            const result = streamText({ model: cloudflareModel, messages });
-            return result.toDataStreamResponse();
+            return new Response(cfRes.body, {
+              headers: { "Content-Type": "text/event-stream" },
+            });
           }
           default:
             return new Response("Unknown provider", { status: 400 });
@@ -120,20 +128,85 @@ export default {
         }
       }
       case "/api/projects": {
-        // Apps Script integration removed due to security and runtime incompatibility issues
-        // This feature would require using the Google Apps Script API instead of clasp CLI
-        return new Response(JSON.stringify({ error: "Apps Script integration temporarily disabled" }), {
-          status: 501,
-          headers: { "Content-Type": "application/json" }
-        });
+        if (!env.GOOGLE_APPS_SCRIPT_API_KEY) {
+          return new Response(JSON.stringify({ error: "Google Apps Script API key not configured" }), { 
+            status: 500, 
+            headers: { "Content-Type": "application/json" } 
+          });
+        }
+        
+        try {
+          const res = await fetch(
+            `https://script.googleapis.com/v1/projects?key=${env.GOOGLE_APPS_SCRIPT_API_KEY}`,
+            {
+              headers: {
+                "Accept": "application/json",
+              },
+            }
+          );
+          
+          if (!res.ok) {
+            return new Response(JSON.stringify({ error: "Failed to fetch projects" }), { 
+              status: res.status,
+              headers: { "Content-Type": "application/json" } 
+            });
+          }
+          
+          const data = await res.json();
+          return new Response(JSON.stringify(data), { 
+            headers: { "Content-Type": "application/json" } 
+          });
+        } catch (error) {
+          return new Response(JSON.stringify({ error: "Failed to connect to Google Apps Script API" }), { 
+            status: 500,
+            headers: { "Content-Type": "application/json" } 
+          });
+        }
       }
       case "/api/project/files": {
-        // Apps Script integration removed due to security and runtime incompatibility issues
-        // This feature would require using the Google Apps Script API instead of clasp CLI
-        return new Response(JSON.stringify({ error: "Apps Script integration temporarily disabled" }), {
-          status: 501,
-          headers: { "Content-Type": "application/json" }
-        });
+        const id = url.searchParams.get("id");
+        if (!id || !/^[a-zA-Z0-9_-]+$/.test(id)) {
+          return new Response("Invalid or missing id", { status: 400 });
+        }
+        
+        if (!env.GOOGLE_APPS_SCRIPT_API_KEY) {
+          return new Response(JSON.stringify({ error: "Google Apps Script API key not configured" }), { 
+            status: 500, 
+            headers: { "Content-Type": "application/json" } 
+          });
+        }
+        
+        try {
+          const res = await fetch(
+            `https://script.googleapis.com/v1/projects/${id}/content?key=${env.GOOGLE_APPS_SCRIPT_API_KEY}`,
+            {
+              headers: {
+                "Accept": "application/json",
+              },
+            }
+          );
+          
+          if (!res.ok) {
+            return new Response(JSON.stringify({ error: "Failed to fetch project files" }), { 
+              status: res.status,
+              headers: { "Content-Type": "application/json" } 
+            });
+          }
+          
+          const data = await res.json();
+          
+          // Extract file names from the Apps Script project content
+          const files = data.files ? data.files.map((file: any) => file.name) : [];
+          
+          return new Response(JSON.stringify({ files }), { 
+            headers: { "Content-Type": "application/json" } 
+          });
+        } catch (error) {
+          return new Response(JSON.stringify({ error: "Failed to connect to Google Apps Script API" }), { 
+            status: 500,
+            headers: { "Content-Type": "application/json" } 
+          });
+        }
       }
       default: {
         return new Response(null, { status: 404 });


### PR DESCRIPTION
## Summary
- add guidelines for Codex in `AGENTS.md`
- extend chat to select provider/model and pull models dynamically
- integrate Apps Script project listing and file browsing
- implement provider routes for Gemini, OpenAI and Workers AI
- document new environment variables

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685caecca720832e94b8dd0139027f48